### PR TITLE
Rework hero tagline (broader than marketplace)

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,15 +77,15 @@
     <main id="main-content">
       <section class="hero" id="top">
         <div class="container hero__content">
-          <p class="hero__status" data-reveal>Available for partner conversations</p>
+          <p class="hero__status" data-reveal>Available for product and partner conversations</p>
           <p class="hero__eyebrow" data-reveal>Product Manager · Microsoft Security</p>
           <h1 class="hero__title" data-reveal>
-            Building the marketplace where <span class="gradient-text">AI agents</span> ship to enterprise security.
+            Building the <span class="gradient-text">agentic AI</span> that defends the enterprise.
           </h1>
           <p class="hero__summary" data-reveal>
-            I own product strategy for the partner ecosystem of the <strong>Microsoft Security Store</strong> and contribute to
-            <strong>Microsoft Security Copilot</strong> strategy. My job is making it easy for partners (CSPs, MSSPs, and security
-            ISVs) to build and ship agentic AI solutions across Defender, Sentinel, Entra, Purview, and Intune.
+            I'm a Product Manager in Microsoft Security working on agentic AI for the enterprise. That spans the partner ecosystem of
+            the <strong>Microsoft Security Store</strong> and <strong>Microsoft Security Copilot</strong> strategy, helping partners
+            and product teams build and ship AI agents across Defender, Sentinel, Entra, Purview, and Intune.
           </p>
           <div class="hero__actions" data-reveal>
             <a class="button button--primary" href="#experience">View experience</a>


### PR DESCRIPTION
Broadens the hero from marketplace-specific to the wider agentic-AI-in-enterprise-security positioning.

- New h1: 'Building the agentic AI that defends the enterprise.'
- Summary opens broad (agentic AI for the enterprise), then keeps Microsoft Security Store + Security Copilot as parts of the bigger story.
- Status line broadened to 'product and partner conversations'.

Validate and build pass.